### PR TITLE
Adding display_override to incubations spec

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,0 +1,4 @@
+{
+    "src_file": "index.html",
+    "type": "respec"
+}

--- a/index.html
+++ b/index.html
@@ -53,9 +53,9 @@
       <p>
         The following shows a [=manifest=] that prefers the
         <code>minimal-ui</code> <a data-cite=
-        "appmanifest#dfn-display-mode">display modes</a> to
-        <code>standalone</code>, but if minimal-ui isn't supported, fall back
-        to standalone as opposed to browser.
+        "appmanifest#dfn-display-mode">display mode</a> over
+        <code>standalone</code>, but if <code>minimal-ui</code> isn't supported, falls back
+        to <code>standalone</code> as opposed to <code>browser</code>.
       </p>
       <pre class="example json" title="Advanced display usage manifest">
         {

--- a/index.html
+++ b/index.html
@@ -8,17 +8,22 @@
       // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
       var respecConfig = {
         specStatus: "CG-DRAFT",
-        shortName: "beforeinstallprompt",
         editors: [{
           name: "Marcos Cáceres"
-        }]
+        }],
+        github: "WICG/manifest-incubations",
+        shortName: "manifest-incubations",
+        xref: {
+          specs: ["appmanifest"],
+          profile: "web-platform",
+        },
       };
     </script>
   </head>
   <body>
     <section id="abstract">
       <p>
-        This specification does neat stuff.
+        Feature specifications for manifest extensions & incubations.
       </p>
     </section>
     <section id="sotd">
@@ -34,5 +39,98 @@
         for how toget started!
       </p>
     </section>
+
+    <section class="informative">
+      <h2>
+        Incubation Usage Examples
+      </h2>
+      <p>
+        The following shows a [=manifest=] that prefers the <code>minimal-ui
+        </code> <a data-cite="appmanifest#dfn-display-mode">display modes</a>
+        to <code>standalone</code>, but if minimal-ui isn't supported, fall
+        back to standalone as opposed to browser.
+      </p>
+      <pre class="example json" title="Advanced display usage manifest">
+        {
+          "name": "Recipe Zone",
+          "description": "All of the recipes!",
+          "icons": [{
+            "src": "icon/hd_hi",
+            "sizes": "128x128"
+          }],
+          "start_url": "/index.html",
+          "display_override": ["minimal-ui"],
+          "display": "standalone",
+          "theme_color": "yellow",
+          "background_color": "red"
+        }
+      </pre>
+    </section>
+
+    <section>
+      <h2 data-dft-for="">Display_override extension</h2>
+      <p>
+        For advanced usages, the display_override member can be used to specify
+        a custom fallback order of {DisplayModeType}}s for developers to choose
+        their prefered <a data-cite="appmanifest#dfn-display-mode">display mode
+        </a>.
+      </p>
+      <p>
+        The <dfn>extension point for evaluating display_override</dfn> is given
+        by the following algorithm addition to the
+        <a data-cite="appmanifest#dfn-steps-for-determing-the-web-app-s-chosen-display-mode">
+        steps for determining the web app's chosen display mode</a>. The
+        following algorithm is executed at the
+        <a data-cite="appmanifest#dfn-extension-point">extension point</a>:
+      </p>
+      <ol>
+        <li>
+          [=list/For each=] |candidate_display_mode:DisplayModeType| of
+          |manifest|.{{WebAppManifest/display_override}}:
+          <ol>
+            <li>
+              If the user agent supports the |candidate_display_mode|, then
+              return |candidate_display_mode|.
+            </li>
+          </ol>
+        </li>
+      </ol>
+    </section>
+
+    <section data-dfn-for="WebAppManifestIncubations"
+        data-link-for="WebAppManifestIncubations">
+      <h2>
+        <dfn data-dfn-for="">WebAppManifestIncubations</dfn> dictionary
+      </h2>
+      <pre class="idl">
+          partial dictionary WebAppManifest {
+            sequence&lt;DisplayModeType&gt; display_override;
+          };
+      </pre>
+      <p>
+        This is an expansion of {{WebAppManifest}}.
+      </p>
+      <section>
+        <h3>
+          <code>display_override</code> member
+        </h3>
+        <p>
+          The <dfn>display_override</dfn> member is a <a>sequence</a> of {{
+          DisplayModeType}}. This item represents the developer's preferred
+          fallback chain for <a data-cite="appmanifest#dfn-display-mode">
+          display modes</a>. This field overrides the
+          {{WebAppManifest/display}} property. If the user agent does not
+          support any of the display modes specified here, then it falls back
+          to considering the {{WebAppManifest/display}} field. See
+          <a data-cite="appmanifest#dfn-display-mode">display modes</a> for the
+          algorithm steps.
+        </p>
+        <p class="note">
+          This member is intended to be only used for advanced cases, where
+          the developer wants explicit control over the fallback order of their
+          display modes. Otherwise, the {{WebAppManifest/display}} should be sufficient for
+          most use cases.
+        </p>
+      </section>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,15 +1,18 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Spec proposal</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+    <title>
+      Spec proposal
+    </title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class=
+    "remove"></script>
     <script class='remove'>
       // See https://github.com/w3c/respec/wiki/ for how to configure ReSpec
       var respecConfig = {
         specStatus: "CG-DRAFT",
         editors: [{
-          name: "Marcos Cáceres"
+          name: "Daniel Murphy"
         }],
         github: "WICG/manifest-incubations",
         shortName: "manifest-incubations",
@@ -23,7 +26,10 @@
   <body>
     <section id="abstract">
       <p>
-        Feature specifications for manifest extensions & incubations.
+        Feature specifications for manifest extensions & incubations which
+        Chromium has shipped but do not have committments / implementations
+        from other user agents. Instead of keeping these features as
+        explainers, they are documented more officially here.
       </p>
     </section>
     <section id="sotd">
@@ -31,24 +37,25 @@
         This is an unofficial proposal.
       </p>
     </section>
-
     <section id="introduction">
-      <h2>Introduction</h2>
+      <h2>
+        Introduction
+      </h2>
       <p>
-        See <a href="https://github.com/w3c/respec/wiki/User's-Guide">ReSpec's user guide</a>
-        for how toget started!
+        See <a href="https://github.com/w3c/respec/wiki/User's-Guide">ReSpec's
+        user guide</a> for how toget started!
       </p>
     </section>
-
     <section class="informative">
       <h2>
         Incubation Usage Examples
       </h2>
       <p>
-        The following shows a [=manifest=] that prefers the <code>minimal-ui
-        </code> <a data-cite="appmanifest#dfn-display-mode">display modes</a>
-        to <code>standalone</code>, but if minimal-ui isn't supported, fall
-        back to standalone as opposed to browser.
+        The following shows a [=manifest=] that prefers the
+        <code>minimal-ui</code> <a data-cite=
+        "appmanifest#dfn-display-mode">display modes</a> to
+        <code>standalone</code>, but if minimal-ui isn't supported, fall back
+        to standalone as opposed to browser.
       </p>
       <pre class="example json" title="Advanced display usage manifest">
         {
@@ -66,39 +73,35 @@
         }
       </pre>
     </section>
-
     <section>
-      <h2 data-dft-for="">Display_override extension</h2>
+      <h2 data-dft-for="">
+        Display_override extension
+      </h2>
       <p>
         For advanced usages, the display_override member can be used to specify
         a custom fallback order of {DisplayModeType}}s for developers to choose
-        their prefered <a data-cite="appmanifest#dfn-display-mode">display mode
-        </a>.
+        their prefered <a data-cite="appmanifest#dfn-display-mode">display
+        mode</a> .
       </p>
       <p>
-        The <dfn>extension point for evaluating display_override</dfn> is given
-        by the following algorithm addition to the
-        <a data-cite="appmanifest#dfn-steps-for-determing-the-web-app-s-chosen-display-mode">
-        steps for determining the web app's chosen display mode</a>. The
-        following algorithm is executed at the
-        <a data-cite="appmanifest#dfn-extension-point">extension point</a>:
+        The following steps are added to the <a data-cite=
+        "appmanifest#dfn-extension-point">extension point</a> in <a data-cite=
+        "appmanifest#dfn-steps-for-determing-the-web-app-s-chosen-display-mode">
+        determining the web app's chosen display mode</a>:
       </p>
       <ol>
-        <li>
-          [=list/For each=] |candidate_display_mode:DisplayModeType| of
-          |manifest|.{{WebAppManifest/display_override}}:
+        <li>[=list/For each=] |candidate_display_mode:DisplayModeType| of
+        |manifest|.{{WebAppManifest/display_override}}:
           <ol>
-            <li>
-              If the user agent supports the |candidate_display_mode|, then
-              return |candidate_display_mode|.
+            <li>If the user agent supports the |candidate_display_mode|, then
+            return |candidate_display_mode|.
             </li>
           </ol>
         </li>
       </ol>
     </section>
-
-    <section data-dfn-for="WebAppManifestIncubations"
-        data-link-for="WebAppManifestIncubations">
+    <section data-dfn-for="WebAppManifestIncubations" data-link-for=
+    "WebAppManifestIncubations">
       <h2>
         <dfn data-dfn-for="">WebAppManifestIncubations</dfn> dictionary
       </h2>
@@ -108,7 +111,7 @@
           };
       </pre>
       <p>
-        This is an expansion of {{WebAppManifest}}.
+        This is an extension of {{WebAppManifest}}.
       </p>
       <section>
         <h3>
@@ -117,20 +120,21 @@
         <p>
           The <dfn>display_override</dfn> member is a <a>sequence</a> of {{
           DisplayModeType}}. This item represents the developer's preferred
-          fallback chain for <a data-cite="appmanifest#dfn-display-mode">
-          display modes</a>. This field overrides the
-          {{WebAppManifest/display}} property. If the user agent does not
-          support any of the display modes specified here, then it falls back
-          to considering the {{WebAppManifest/display}} field. See
+          fallback chain for <a data-cite=
+          "appmanifest#dfn-display-mode">display modes</a>. This field
+          overrides the {{WebAppManifest/display}} property. If the user agent
+          does not support any of the display modes specified here, then it
+          falls back to considering the {{WebAppManifest/display}} field. See
           <a data-cite="appmanifest#dfn-display-mode">display modes</a> for the
           algorithm steps.
         </p>
         <p class="note">
-          This member is intended to be only used for advanced cases, where
-          the developer wants explicit control over the fallback order of their
-          display modes. Otherwise, the {{WebAppManifest/display}} should be sufficient for
-          most use cases.
+          This member is intended to be only used for advanced cases, where the
+          developer wants explicit control over the fallback order of their
+          display modes. Otherwise, the {{WebAppManifest/display}} should be
+          sufficient for most use cases.
         </p>
       </section>
+    </section>
   </body>
 </html>

--- a/tidyconfig.txt
+++ b/tidyconfig.txt
@@ -1,0 +1,6 @@
+char-encoding: utf8
+indent: yes
+indent-spaces: 2
+wrap: 80
+tidy-mark: no
+custom-tags: yes


### PR DESCRIPTION
@mgiuca  / @marcoscaceres , I'm trying to figure out how to structure this document - this is a first draft of adding display_override to this spec, assuming the editorial changes of this pull request go through:
https://github.com/w3c/manifest/pull/949 

What do you think? Should I do this a different way?

Thanks!
Daniel